### PR TITLE
Include file paths in tap runner output

### DIFF
--- a/lib/test/unit/runner/tap.rb
+++ b/lib/test/unit/runner/tap.rb
@@ -1,5 +1,6 @@
 require 'test-unit'
 require 'test/unit/runner/tap-version'
+require 'test/unit/ui/tap/ext/base_testrunner'
 
 module Test
   module Unit

--- a/lib/test/unit/ui/tap/ext/base_testrunner.rb
+++ b/lib/test/unit/ui/tap/ext/base_testrunner.rb
@@ -1,0 +1,62 @@
+require 'test/unit/ui/tap/base_testrunner'
+
+module Test
+  module Unit
+    module UI
+      module Tap
+        class Tap::BaseTestRunner < Test::Unit::UI::TestRunner
+
+          def tapout_pass_with_source_location(test)
+            doc = tapout_pass_without_source_location(test)
+            if(doc && doc['type'] == 'test')
+              file, _ = test.class.instance_method(clean_label(test.name).to_sym).source_location
+              doc['file'] = file.sub(Dir.pwd+'/', '')
+            end
+            doc
+          end
+
+          def tapout_todo_with_source_location(fault)
+            doc = tapout_todo(fault)
+            doc['file'] = extract_source_location
+            doc
+          end
+
+          def tapout_omit_with_source_location(fault)
+            doc = tapout_omit_without_source_location(fault)
+            doc['file'] = extract_source_location(fault) if doc
+            doc
+          end
+
+          def tapout_fail_with_source_location(fault)
+            doc = tapout_fail_without_source_location(fault)
+            doc['file'] = extract_source_location(fault) if doc
+            doc
+          end
+
+          def tapout_error_with_source_location(fault)
+            doc =  tapout_error_without_source_location(fault)
+            doc['file'] = extract_source_location(fault) if doc
+            doc
+          end
+
+          alias_method :tapout_pass_without_source_location, :tapout_pass
+          alias_method :tapout_pass, :tapout_pass_with_source_location
+          alias_method :tapout_omit_without_source_location, :tapout_omit
+          alias_method :tapout_omit, :tapout_omit_with_source_location
+          alias_method :tapout_fail_without_source_location, :tapout_fail
+          alias_method :tapout_fail, :tapout_fail_with_source_location
+          alias_method :tapout_error_without_source_location, :tapout_error
+          alias_method :tapout_error, :tapout_error_with_source_location
+          alias_method :tapout_todo_without_source_location, :tapout_todo
+          alias_method :tapout_todo, :tapout_todo_with_source_location
+
+          private
+            def extract_source_location(fault)
+              file, _ = location(fault.location)
+              file.sub(Dir.pwd+'/', '')
+            end
+        end
+      end
+    end
+  end
+end

--- a/test/test_tapy.rb
+++ b/test/test_tapy.rb
@@ -45,7 +45,7 @@ class TapYTest < Test::Unit::TestCase
     file = "test/fixtures/test_example.rb"
     assert_equal "Test::Unit::Failure",    @failing_test['exception']['class']
     assert_equal file,                     @failing_test['exception']['file']
-    assert_equal 12,                       @failing_test['exception']['line']
+    assert_equal 10,                       @failing_test['exception']['line']
     assert_equal "assert_equal('1', '2')", @failing_test['exception']['source']
   end
 
@@ -64,7 +64,7 @@ class TapYTest < Test::Unit::TestCase
     file = "test/fixtures/test_example.rb"
     assert_equal 'Test::Unit::Error', @erring_test['exception']['class']
     assert_equal file,                @erring_test['exception']['file']
-    assert_equal 8,                   @erring_test['exception']['line']
+    assert_equal 6,                   @erring_test['exception']['line']
     assert_equal 'raise',             @erring_test['exception']['source']
   end
 

--- a/test/test_tapy.rb
+++ b/test/test_tapy.rb
@@ -33,10 +33,12 @@ class TapYTest < Test::Unit::TestCase
 
   def test_passing_should_have_correct_label
     assert_equal 'test_passing', @passing_test['label']
+    assert_equal 'test/fixtures/test_example.rb', @passing_test['file']
   end
 
   def test_failing_should_have_correct_label
     assert_equal "test_failing", @failing_test['label']
+    assert_equal "test/fixtures/test_example.rb", @failing_test['file']
   end
 
   def test_failing_should_hash_correct_exception
@@ -55,6 +57,7 @@ class TapYTest < Test::Unit::TestCase
 
   def test_erring_should_have_correct_label
     assert_equal 'test_error', @erring_test['label']
+    assert_equal 'test/fixtures/test_example.rb', @erring_test['file']
   end
 
   def test_erring_should_have_correct_exception


### PR DESCRIPTION
This PR changes the `test-unit-runner-tap` to include source file location for each tests. This will be useful in calculating duration taken by each test file. 

This is done by extending listener methods in the `BaseTestRunner` class. It will be easy to keep updated with the parent branch.

JSON output: https://gist.github.com/snehaso/6aedfdd18d91cb1486da
